### PR TITLE
prevent error with class Event

### DIFF
--- a/front/simcard.form.php
+++ b/front/simcard.form.php
@@ -27,6 +27,7 @@
  @link      http://www.glpi-project.org/
  @since     2009
  ---------------------------------------------------------------------- */
+use Glpi\Event;
 
 include ('../../../inc/includes.php');
 


### PR DESCRIPTION
Event class have a namespace because this name is used by PHP

need to specify namespace